### PR TITLE
Aws create table update

### DIFF
--- a/DependencyInjection/Compiler/DynamoDbTablePass.php
+++ b/DependencyInjection/Compiler/DynamoDbTablePass.php
@@ -8,12 +8,8 @@
 
 namespace GWK\DynamoSessionBundle\DependencyInjection\Compiler;
 
-use Aws\Common\Exception\InstanceProfileCredentialsException;
-use Aws\Common\Exception\InvalidArgumentException;
 use Aws\DynamoDb\DynamoDbClient;
-use Aws\DynamoDb\Exception\ResourceNotFoundException;
-use GWK\DynamoSessionBundle\Handler\SessionHandler;
-use Guzzle\Service\Resource\Model;
+use Aws\DynamoDb\Exception\DynamoDbException;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\Exception\LogicException;
@@ -30,24 +26,40 @@ class DynamoDbTablePass implements CompilerPassInterface
             return;
         }
 
-        /** @var $client DynamoDbClient */
+        /** @var DynamoDbClient $client */
         $client = $container->get("dynamo_session_client");
 
         $tableName = $container->getParameter("dynamo_session_table");
 
         try {
-            /** @var $table Model */
-            $client->describeTable(array('TableName' => $tableName));
-        } catch(InstanceProfileCredentialsException $e) {
-            throw new LogicException("Invalid DynamoDB security credentials or insufficient permissions", $e->getCode(), $e);
-        } catch(ResourceNotFoundException $e) {
-            /** @var $handler SessionHandler */
-            $handler = $container->get("dynamo_session_handler");
+            $client->describeTable(['TableName' => $tableName]);
+        } catch(DynamoDbException $e) {
+            if ($e->getAwsErrorCode() === 'ResourceNotFoundException') {
+                $read_capacity = $container->getParameter("dynamo_session_read_capacity");
+                $write_capacity = $container->getParameter("dynamo_session_write_capacity");
 
-            $read_capacity = $container->getParameter("dynamo_session_read_capacity");
-            $write_capacity = $container->getParameter("dynamo_session_write_capacity");
-
-            $handler->getHandler()->createSessionsTable($read_capacity, $write_capacity);
+                $client->createTable([
+                    'TableName' => $tableName,
+                    'AttributeDefinitions' => [
+                        [
+                            'AttributeName' => 'id',
+                            'AttributeType' => 'S'
+                        ]
+                    ],
+                    'KeySchema' => [
+                        [
+                            'AttributeName' => 'id',
+                            'KeyType' => 'HASH'
+                        ]
+                    ],
+                    'ProvisionedThroughput' => [
+                        'ReadCapacityUnits' => $read_capacity,
+                        'WriteCapacityUnits' => $write_capacity
+                    ]
+                ]);
+            } else {
+                throw new LogicException("Invalid DynamoDB security credentials or insufficient permissions", $e->getCode(), $e);
+            }
         }
     }
 }


### PR DESCRIPTION
In aws-sdk-v3 
```
use Aws\Common\Exception\InstanceProfileCredentialsException;
use Aws\Common\Exception\InvalidArgumentException;
```
are deprecated and replaced with 
`use Aws\DynamoDb\Exception\DynamoDbException;`

-> createSessionsTable is deprecated in v3 and we are supposed to use createTable instead